### PR TITLE
Added user/password auth to mqtt connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ port = 1883
 enable_tls = false
 force_protocol_version_3_1 = true
 
+enable_auth = false
+username = ""
+password = ""
+
 topic_prefix = "hue2mqtt"
 
 [hue]

--- a/hue2mqtt/config.py
+++ b/hue2mqtt/config.py
@@ -27,6 +27,9 @@ class MQTTBrokerInfo(BaseModel):
 
     host: str
     port: int
+    enable_auth: bool = False
+    username: str = ""
+    password: str = ""
     enable_tls: bool = False
     topic_prefix: str = "hue2mqtt"
     force_protocol_version_3_1: bool = False

--- a/hue2mqtt/mqtt/wrapper.py
+++ b/hue2mqtt/mqtt/wrapper.py
@@ -82,7 +82,10 @@ class MQTTWrapper:
 
         if self._broker_info.enable_auth:
             LOGGER.debug("MQTT Auth enabled")
-            self._client.set_auth_credentials(self._broker_info.username,self._broker_info.password)
+            self._client.set_auth_credentials(
+                self._broker_info.username,
+                self._broker_info.password,
+            )
 
         await self._client.connect(
             self._broker_info.host,

--- a/hue2mqtt/mqtt/wrapper.py
+++ b/hue2mqtt/mqtt/wrapper.py
@@ -80,6 +80,10 @@ class MQTTWrapper:
         if self._broker_info.force_protocol_version_3_1:
             mqtt_version = gmqtt.constants.MQTTv311
 
+        if self._broker_info.enable_auth:
+            LOGGER.debug("MQTT Auth enabled")
+            self._client.set_auth_credentials(self._broker_info.username,self._broker_info.password)
+
         await self._client.connect(
             self._broker_info.host,
             port=self._broker_info.port,


### PR DESCRIPTION
Attached in the pull request. Added three variables to the config file, the username and password and an enable_auth flag. Then used these with mqtt connect function to authenticate.