### PR TITLE
Allow buttonevent on Dimmer Switch to be None

### DIFF
--- a/hue2mqtt/schema.py
+++ b/hue2mqtt/schema.py
@@ -105,7 +105,7 @@ class RotarySensorState(GenericSensorState):
 class SwitchSensorState(GenericSensorState):
     """Information about the state of a sensor."""
 
-    buttonevent: int
+    buttonevent: Optional[int]
 
 
 class LightLevelSensorState(GenericSensorState):


### PR DESCRIPTION
When a bridge is restarted, and then Hue2MQTT is restarted without a button being pressed,
the button will have no state set.

Fixes #9 and fixes #10